### PR TITLE
fix: subscription procedure should use onData, not onNext

### DIFF
--- a/src/createTRPCJotai.ts
+++ b/src/createTRPCJotai.ts
@@ -107,7 +107,7 @@ const atomWithSubscription = <
         error: (err: unknown) => void;
       }) => {
         const callbacks = {
-          onNext: arg.next.bind(arg),
+          onData: arg.next.bind(arg),
           onError: arg.error.bind(arg),
         };
         const unsubscribable = procedure.subscribe(input, {


### PR DESCRIPTION
I referenced the implementation of the vanilla trpc client [here](https://github.com/trpc/trpc/blob/69349665fff2d5d5c70021b22463663c767f7ae7/examples/fastify-server/src/client/index.ts#L47) since the v10 docs are light on the topic.

In a barebones vite project, without this fix any components using `atomWithSubscription` will be in suspense indefinitely without any noticeable error. This is with `@trpc/client@10.45.2`. I imagine this could all go out the window with v11.